### PR TITLE
Allow to chose between reqwest and surf, bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobc-arangors"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rafael Aggeler <r.aggeler@gmx.net>"]
 license = "MIT"
 description = "ArangoDB support for the async mobc connection pool"
@@ -8,9 +8,13 @@ repository = "https://github.com/inzanez/mobc-arangors"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = [ "reqwest" ]
+reqwest = [ "arangors/rocksdb", "arangors/reqwest_async" ]
+surf = [ "arangors/rocksdb", "arangors/surf_async" ]
 
 [dependencies]
-arangors = "0.3"
+arangors = { version = ">=0.4.3", default-features=false, optional = true }
 mobc = "0.5.10"
 futures = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
-use mobc::{Manager, async_trait};
+use arangors::connection::role::Normal;
 use arangors::ClientError;
+use mobc::{async_trait, Manager};
+
+#[cfg(feature = "reqwest")]
+use arangors::client::reqwest::ReqwestClient;
+#[cfg(feature = "surf")]
+use arangors::client::surf::SurfClient;
 
 #[derive(Clone, Debug)]
 pub struct ArangoDBConnectionManager {
@@ -33,26 +39,46 @@ impl Manager for ArangoDBConnectionManager {
     type Connection = arangors::Connection;
     type Error = ClientError;
 
-   async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-      if self.use_jwt == true {
-          let client = arangors::Connection::establish_jwt(&self.url, &self.username, &self.password).await?;
-          return Ok(client);
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        if self.use_jwt == true {
+            let client =
+                arangors::Connection::establish_jwt(&self.url, &self.username, &self.password)
+                    .await?;
+            return Ok(client);
+        } else {
+            let client = arangors::Connection::establish_basic_auth(
+                &self.url,
+                &self.username,
+                &self.password,
+            )
+            .await?;
+            return Ok(client);
+        }
+    }
 
-      } else {
-          let client = arangors::Connection::establish_basic_auth(&self.url, &self.username, &self.password).await?;
-          return Ok(client);
-      }
-   }
+    #[cfg(feature = "surf")]
+    async fn check(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
+        if self.validate {
+            arangors::connection::GenericConnection::<SurfClient, Normal>::validate_server(
+                &self.url,
+            )
+            .await?;
+        }
 
-   async fn check(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-       if self.validate {
-           conn.validate_server().await?;
-       }
+        Ok(conn)
+    }
+    #[cfg(feature = "reqwest")]
+    async fn check(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
+        if self.validate {
+            arangors::connection::GenericConnection::<ReqwestClient, Normal>::validate_server(
+                &self.url,
+            )
+            .await?;
+        }
 
-       Ok(conn)
-   }
+        Ok(conn)
+    }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Let users choose between `reqwest` and `surf` client. Fixed `validate` method to work with new `arangors` implementation.